### PR TITLE
Serve cordova javascript from browser platform

### DIFF
--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -57,6 +57,30 @@ app.use(hotMiddleware)
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
 app.use(staticPath, express.static('./static'))
 
+
+// serve Cordova javascript and plugins
+var cordovaPlatformPath = path.join(__dirname, '../platforms/browser/www');
+var pluginPath = path.posix.join(config.dev.assetsPublicPath, 'plugins')
+app.use(pluginPath, express.static(path.join(cordovaPlatformPath, 'plugins')))
+
+app.get(
+  [
+    path.posix.join(config.dev.assetsPublicPath, 'cordova.js'),
+    path.posix.join(config.dev.assetsPublicPath, 'cordova_plugins.js'),
+  ],
+  function(req, res){
+    var reqPath = req.path;
+    if(reqPath.substr(-1) == '/') {
+      reqPath = reqPath.slice(0, -1);
+    }
+
+    try {
+      res.sendFile(path.join(cordovaPlatformPath, reqPath));
+    } catch(err) {
+      console.log(err);
+    }
+})
+
 module.exports = app.listen(port, function (err) {
   if (err) {
     console.log(err)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
     "ios": "cordova run ios --target=\"iPhone-4s\"",
-    "lint": "eslint --ext .js,.vue src"
+    "lint": "eslint --ext .js,.vue src",
+    "browser": "cordova prepare browser && PORT=3000 node build/dev-server.js"
   },
   "dependencies": {
     "vue": "^2.1.0",

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ Vue.use(VueCordova, {
 })
 
 // add cordova.js only if serving the app through file://
-if (window.location.protocol === 'file:') {
+if (window.location.protocol === 'file:' || window.location.port === '8080') {
   var cordovaScript = document.createElement('script')
   cordovaScript.setAttribute('type', 'text/javascript')
   cordovaScript.setAttribute('src', 'cordova.js')

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ Vue.use(VueCordova, {
 })
 
 // add cordova.js only if serving the app through file://
-if (window.location.protocol === 'file:' || window.location.port === '8080') {
+if (window.location.protocol === 'file:' || window.location.port === '3000') {
   var cordovaScript = document.createElement('script')
   cordovaScript.setAttribute('type', 'text/javascript')
   cordovaScript.setAttribute('src', 'cordova.js')


### PR DESCRIPTION
See #5 

This is more of a 'proof of concept', I'm sure it can be a lot cleaner.

 - Add middleware to catch the cordova.js, cordova_plugins.js and plugins/* calls, to map them to the browser platform 'www' folder.
 - Add `npm run browser` command to prepare the browser folder + run dev server on port 3000
 - On port 3000, also add the cordova.js script.

This would add the Cordova serve functionality (https://www.raymondcamden.com/2016/03/22/the-cordova-browser-platform) for the browser platform (with simple stubs for plugins/events), but keep the hot module reload from Webpack (in contrast to live reload from phonegap)

Obviously plugins are not hot reloaded, but that doesn't change often I think.
